### PR TITLE
Convert turn commands to radian velocity for embedded system compatibility

### DIFF
--- a/ai_interface/naive.py
+++ b/ai_interface/naive.py
@@ -35,9 +35,9 @@ class SoccerAI:
         for robot in game_state.robot_poses[teamname]:
             unum = int(next(iter(robot.keys())))
             if unum == 1:
-                actions.append("kick 100 0" if kick else "dash 100")
+                actions.append("kick 100 0" if kick else "dash 100 0")
             else:
-                actions.append("dash 20")
+                actions.append("dash 20 0")
         return actions
 
     def translate_ai_output(self, ai_output) -> list[str]:

--- a/networking/data_utils.py
+++ b/networking/data_utils.py
@@ -10,6 +10,7 @@ import time
 import math
 from collections import namedtuple
 
+SIM_TIMESTEP = 0.1    # seconds
 # Matches "(see_global <digits> <content>)" and captures server cycle number and
 # remaining data until " ((b"
 SIM_COUNT_REGEX = r"\(see_global (\d+) (.*?)(?=\s\(\(b)"
@@ -132,9 +133,10 @@ class Serializer:
         tail = " ".join(parts[convert_index + 1:])
 
         rad_per_sec = float(parts[convert_index])
-        degrees = (rad_per_sec / math.pi) * 18
-        
-        return f"{head} {degrees} {tail}"
+        degrees = (rad_per_sec / math.pi) * 180.0 * SIM_TIMESTEP
+        normalized_degrees = ((degrees + 180) % 360) - 180
+
+        return f"{head} {normalized_degrees} {tail}"
 
     def sim_serialize(self, actions) -> list[bytes]:
         """

--- a/networking/data_utils.py
+++ b/networking/data_utils.py
@@ -136,7 +136,7 @@ class Serializer:
         degrees = (rad_per_sec / math.pi) * 180.0 * SIM_TIMESTEP
         normalized_degrees = ((degrees + 180) % 360) - 180
 
-        return f"{head} {normalized_degrees} {tail}"
+        return f"{head} {normalized_degrees} {tail}".strip()
 
     def sim_serialize(self, actions) -> list[bytes]:
         """

--- a/networking/data_utils.py
+++ b/networking/data_utils.py
@@ -133,7 +133,8 @@ class Serializer:
         tail = " ".join(parts[convert_index + 1:])
 
         rad_per_sec = float(parts[convert_index])
-        degrees = (rad_per_sec / math.pi) * 180.0 * SIM_TIMESTEP
+        degrees_per_sec = math.degrees(rad_per_sec)
+        degrees =  degrees_per_sec * SIM_TIMESTEP
         normalized_degrees = ((degrees + 180) % 360) - 180
 
         return f"{head} {normalized_degrees} {tail}".strip()


### PR DESCRIPTION
## Summary

Resolves #3 - Converts turn commands from degree distance to radian velocity to optimize embedded system performance.

### Key Changes:
- **Added `_convert_command_for_simulator()` method** in `data_utils.py` to convert rad/s to degrees for simulator compatibility
- **Updated `sim_serialize()` method** to automatically detect and convert `turn` and `dash` commands  
- **Modified `naive.py`** to include direction parameter in dash commands for consistency
- **Added `SIM_TIMESTEP` constant** (0.1s) for accurate time-based conversions

### Technical Details:
- **Robot path**: Commands with rad/s sent directly to embedded system ✅
- **Simulator path**: Commands automatically converted to degrees using formula: `degrees = (rad_per_sec / π) * 180 * 0.1`
- **Normalization**: Angles normalized to [-180, 180) range for simulator compatibility
- **Embedded optimization**: Eliminates need for embedded system to handle degree-to-radian conversion and timing loops

This change reduces computational load on the resource-constrained embedded system while maintaining full simulator compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)