### PR TITLE
Prefix robot commands with robot ID

### DIFF
--- a/networking/data_utils.py
+++ b/networking/data_utils.py
@@ -239,11 +239,13 @@ class Serializer:
             Serialized command bytes for robot transmission
         """
         message = ""
+        robot_id = 1
         for action in actions:
             if action is None:
-                message += "None\n"
+                message += f"{robot_id} None\n"
             else:
-                message += action + "\n"
+                message += f"{robot_id} {action}\n"
+            robot_id += 1
         
         return message.encode()
 


### PR DESCRIPTION
## Summary

Resolves #4

This PR implements robot ID prefixing for all commands to improve clarity in parsing.

## Changes

- Modified `robot_serialize()` in [networking/data_utils.py](networking/data_utils.py) to prefix each command with a sequential robot ID
- Commands now follow the format: `<robot_id> <command> <command_parameters>`

## Examples

**Before:**
```
dash 100 0
turn 45
kick 80 0
```

**After:**
```
1 dash 100 0
2 turn 45
3 kick 80 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)